### PR TITLE
Allow LOGIN_URLS without the need to decorate with `allow`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1
+
+* The login URLs do not need to be explicitly allowed.
+
 ## 1.0
 
 * Validated the package against a production site.

--- a/src/denied/middleware.py
+++ b/src/denied/middleware.py
@@ -45,6 +45,10 @@ class DeniedMiddleware:
             return redirect_to_login(request.get_full_path())
 
         if not hasattr(view_func, "__denied_authorizer__"):
+            # Permit the login URLs always.
+            if request.path in LOGIN_URLS:
+                return None
+
             return HttpResponseForbidden()
 
         # __denied_authorizer__ is set by the various decorators.

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -63,6 +63,19 @@ class TestDeniedMiddleware:
         # chain to continue.
         assert ret is None
 
+    def test_login_allowed(self):
+        """The login page does not need to be allowed explicitly."""
+
+        request = self.rf.get(settings.LOGIN_URL)
+        request.user = AnonymousUser()
+        middleware = DeniedMiddleware(get_response)
+
+        ret = middleware.process_view(request, get_response, [], {})
+
+        # The contract of the middleware is that None permits the middleware
+        # chain to continue.
+        assert ret is None
+
     def test_authentication_exempt(self):
         """A view is exempt from authentication checking."""
 


### PR DESCRIPTION
Fixes #4